### PR TITLE
Client: consider status_code == 1000 on logout action to be OK

### DIFF
--- a/lib/joker-dmapi/client.rb
+++ b/lib/joker-dmapi/client.rb
@@ -40,8 +40,9 @@ module JokerDMAPI
 
     def query(request, params = {})
       response = query_no_raise request, params
-      raise_response(response) unless response[:headers][:status_code] == '0'
-      response
+      return response if response[:headers][:status_code] == '0'
+      return response if (request == :logout) && (response[:headers][:status_code] == '1000')
+      raise_response(response)
     end
 
     def tlds


### PR DESCRIPTION
Joker seems to have changed their API a while ago. Before it always
returned `status_code: 0` for successful requests, even for the
`logout` request.

Nowadays the API returns `status_code: 1000` when logging out. Full
example of a reply:

```
status_code: 1000
status_text: OK
svtrid: 01d30…
tracking_id: 01d30…
timing: 0.001976/0.005268 37.504%

Session destroyed
```

Fixes #1.